### PR TITLE
Changed from ConstantColumn to RelativeColumn

### DIFF
--- a/src/QuestPDF.Markdown/MarkdownRenderer.cs
+++ b/src/QuestPDF.Markdown/MarkdownRenderer.cs
@@ -120,7 +120,13 @@ internal sealed class MarkdownRenderer : IComponent
                     // Width is set to 0 for relative columns
                     if (col.Width > 0)
                     {
-                        cd.ConstantColumn(col.Width);
+                        // Make a relative column out of ?/4
+                        var fraction = Math.Round(col.Width / 25);
+                        if(result <= 1)
+                        {
+                            cd.RelativeColumn();
+                        }
+                        cd.RelativeColumn(fraction);
                     }
                     else
                     {


### PR DESCRIPTION
Markdig col.Width is returning a percentage, this making the constant column that is expecting a point value very small column when rendered. This divides 100 into a fraction of 4 to calculate the relative column.